### PR TITLE
Using 'nantes open data' instead of 'transitfeed'

### DIFF
--- a/nantes/nantes.md
+++ b/nantes/nantes.md
@@ -6,12 +6,10 @@ cityname: Nantes
 coordinates:
 - -1.553621
 - 47.218371
-description: ''
+description: 'Nantes is a city in western France on the Loire River, 50 km (31 mi) from the Atlantic coast'
 gtfs:
-  semitan-592:
-    sha256: d2e228b2b5d7f27255f53c389cd15e0302d401b6139e24a14385454e2479d8c7
-    tf_feed_id: semitan/592
-    url: https://api.transitfeeds.com/v1/getLatestFeedVersion?key=6fbe365a-00b6-4810-a2bc-eaa4be57040c&feed=semitan%2F592
+  open-data-nantes:
+    url: http://data.nantes.fr/fileadmin/data/datastore/nm/mobilite/24440040400129_NM_TAN_00005/ARRETS_HORAIRES_CIRCUITS_TAN_gtfs.zip
 options:
   estimatedMaxCalculateCalls: 55000
 tf_location_ids:


### PR DESCRIPTION
The transitfeed's feed is empty, hence no data is displayed on the map.

url:
`https/api.transitfeeds.com/v1/getLatestFeedVersion?key=6fbe365a-00b6-4810-a2bc-eaa4be57040c&feed=semitan%2F592`

response:
`{"status":"OTHER","ts":1511199822,"msg":"No feed versions found for this feed."}`