### PR TITLE
update Münster URL

### DIFF
--- a/muenster/muenster.md
+++ b/muenster/muenster.md
@@ -1,6 +1,6 @@
 ---
 added: '2018-09-05T07:37:00.390416'
-changed: '2018-09-05T07:37:00.390416'
+changed: '2019-05-20T10:50:00.390416'
 cityid: muenster
 cityname: Münster
 coordinates:
@@ -8,7 +8,8 @@ coordinates:
 - 51.962944
 gtfs:
   swms:
-    sha256: 6bd20c3209c5193f60f5fb62d22c635eaab9db9a4c27a8adc10df01dfe284e3f
+    sha256: 2281fb350c146063231c98c79ed56bee3ca3e603c4d32305b1e6fececd278f32
+    url: https://www.stadtwerke-muenster.de/fileadmin/stwms/busverkehr/kundencenter/dokumente/GTFS/stadtwerke_feed.zip
 version: 1
 zoom: 12
 ---


### PR DESCRIPTION
The GTFS-data is [now publicly available (although without any license as it seems)](https://www.stadtwerke-muenster.de/privatkunden/busverkehr/fahrplaninfos/fahrplaene-netzplaene/open-data-gtfs/gtfs-download.html). I updated the `changed` field, added the URL and used the outcome from `sha256sum stadtwerke_feed.zip` for the `sha256` field.