### PR TITLE
Updated Auckland

### DIFF
--- a/auckland/auckland.md
+++ b/auckland/auckland.md
@@ -1,6 +1,6 @@
 ---
 added: '2010-10-08T20:59:00.985352'
-changed: '2018-08-17T14:57:50.125970'
+changed: '2019-09-23'
 cityid: auckland
 cityname: Auckland
 coordinates:
@@ -9,17 +9,13 @@ coordinates:
 description: ''
 gtfs:
   auckland-transport-124:
-    sha256: b37e1b1a3f4f3a0a3d62bb4316a1063b70f1ab91c0f5785778f7e1e1fb468bb1
     tf_feed_id: auckland-transport/124
-    url: https://transitfeeds-data.s3-us-west-1.amazonaws.com/public/feeds/auckland-transport/124/20180728/gtfs.zip
-options:
-  dataSize: 3501747
-  estimatedMaxCalculateCalls: 560000
+    url: http://transitfeeds.com/p/auckland-transport/124/latest/download
 tf_location_ids:
 - 132-auckland-new-zealand
-version: 3
+version: 4
 zoom: 12
 ---
 
-(c) [MAXX Auckland Regional Transport](http://www.maxx.co.nz/)  
-([Terms of Use](http://www.maxx.co.nz/information/about-maxx/google-transit-feed.html))
+(c) [Auckland Transport](https://at.govt.nz/)  
+([Terms of Use](https://dev-portal.at.govt.nz/terms))


### PR DESCRIPTION
Updated URL to transitfeed's `latest/download` style url. And removed (hopefully unnecessary) parameters.