### PR TITLE
Add Ravensburg

### DIFF
--- a/ravensburg/ravensburg.md
+++ b/ravensburg/ravensburg.md
@@ -4,10 +4,8 @@ cityname: Ravensburg
 coordinates:
 - 9.60645
 - 47.78441
-# Preferably provide a transitfeeds.com location ID, e.g.
 tf_location_ids:
 - 794-ravensburg-germany
-# Or provide GTFS files like so
 gtfs:
   ravensburg:
     tf_feed_id: bodo-verkehrsverbund/1237

--- a/ravensburg/ravensburg.md
+++ b/ravensburg/ravensburg.md
@@ -1,0 +1,20 @@
+---
+cityid: ravensburg
+cityname: Ravensburg
+coordinates:
+- 9.60645
+- 47.78441
+# Preferably provide a transitfeeds.com location ID, e.g.
+tf_location_ids:
+- 794-ravensburg-germany
+# Or provide GTFS files like so
+gtfs:
+  ravensburg:
+    tf_feed_id: bodo-verkehrsverbund/1237
+    url: https://transitfeeds.com/p/bodo-verkehrsverbund/1237/latest/download
+version: 1
+zoom: 12
+---
+
+(c) [Bodensee-Oberschwaben Verkehrsverbund](https://www.bodo.de)
+([Terms of Use](https://www.nvbw.de/aufgaben/digitale-mobilitaet/lizenz/))


### PR DESCRIPTION
Add markdown for Ravensburg.

Be aware that gtfs contains data for the whole Verkehrsverbund Bodensee-Oberschwaben which consists of several cities.
Hope this is ok and we can enjoy lovely Ravensburg in your wonderful project soon.