### PR TITLE
New gtfs url for westfalen-lippe

### DIFF
--- a/westfalen-lippe/westfalen-lippe.md
+++ b/westfalen-lippe/westfalen-lippe.md
@@ -1,6 +1,6 @@
 ---
 added: '2018-09-05T07:37:00.390416'
-changed: '2020-03-10T10:14:08.356349'
+changed: '2021-08-20T10:53:08.356349'
 cityid: westfalen-lippe
 cityname: Westfalen-Lippe
 coordinates:
@@ -8,8 +8,8 @@ coordinates:
 - 51.962944
 gtfs:
   nwl:
-    sha256: 81e94a0e90cab9046079f58cfd19357a95502d39e4ffd878d5cfb743deb02c79
-    url: https://www.opendata-oepnv.de/dataset/121b0b37-b7a8-4663-9eaf-5ed3d38fc38a/resource/e7cb8aa6-7d5c-4f54-975b-75d3d872b1d0/download/gtfs-nwl-20190720.zip
+    sha256: 5af4b01c8ed2a26cce7009a1a7d828510f2ed8d9c831a68de447a04cb76c7009
+    url: https://www.opendata-oepnv.de/dataset/89892705-b6e7-4ffc-977c-2ba9b86dde46/resource/41a8bb9e-70b5-45d9-9414-dc852cba0d2a/download/gtfs-nwl-20210812.zip
 options:
   estimatedMaxCalculateCalls: 6000000
   maxWalkTravelTime: 18000


### PR DESCRIPTION
it seems the old file was taken down by opendata-oepnv